### PR TITLE
[APP-2784] Removing text-left

### DIFF
--- a/components/molecules/Cabinet/Cabinet.js
+++ b/components/molecules/Cabinet/Cabinet.js
@@ -170,7 +170,6 @@ class Cabinet extends Component {
 
     const containerClasses = classNames(
       {
-        'uic--text-left': true,
         'uic--cabinet-container': true,
       },
       className


### PR DESCRIPTION
### Description
> Please provide a brief description of your changes below.

Removes the `text-left` class from the cabinet as it's no longer required now everything lives in a portal.

### Testing Instructions
> What should be done in order to test this pull request, or re-create its effects.

This simply removes the left aligned restriction on the cabinet labels.

### Comments
> Any additional comments that will aid with the review process.

- [JIRA Ticket](https://unitedincome.atlassian.net/browse/app-2784)