### PR TITLE
[APP-2917] Input and DropDown spacing

### DIFF
--- a/components/atoms/Button/Button.md
+++ b/components/atoms/Button/Button.md
@@ -7,11 +7,11 @@ The Button component displays a HTML button.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Button from '@unitedincome/components/dist/Button'
+import Button from '@unitedincome/components/dist/Button';
 ```
 
 ```javascript
-import {Button} from '@unitedincome/components'
+import {Button} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/ChanceOfSuccess/ChanceOfSuccess.md
+++ b/components/atoms/ChanceOfSuccess/ChanceOfSuccess.md
@@ -1,19 +1,18 @@
 # ChanceOfSuccess
 
-The ChanceOfSuccess component displays the users current chance of success in a dial. 
+The ChanceOfSuccess component displays the users current chance of success in a dial.
 
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ChanceOfSuccess from '@unitedincome/components/dist/ChanceOfSuccess'
+import ChanceOfSuccess from '@unitedincome/components/dist/ChanceOfSuccess';
 ```
 
 ```javascript
-import {ChanceOfSuccess} from '@unitedincome/components'
+import {ChanceOfSuccess} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/DropDown/DropDown.js
+++ b/components/atoms/DropDown/DropDown.js
@@ -183,6 +183,7 @@ class DropDown extends Component {
       className,
       clearable,
       description,
+      disableOptionalFlag,
       disabled,
       label,
       loading,
@@ -205,7 +206,7 @@ class DropDown extends Component {
       ComponentType = Select;
       optionProps = {options};
     }
-    if (label && !required) {
+    if (label && !required && !disableOptionalFlag) {
       dropDownLabel = `${label} (Optional)`;
     }
 
@@ -310,6 +311,8 @@ DropDown.propTypes = {
   ),
   /** The currently selected option in the dropdown.  */
   value: PropTypes.string,
+  /** Disables the (Optional) flag when a field is not marked as required. */
+  disableOptionalFlag: PropTypes.bool,
   /** The name of the input field. */
   name: PropTypes.string.isRequired,
   /** Determines if the dropdown input should be disabled or not. */

--- a/components/atoms/DropDown/DropDown.js
+++ b/components/atoms/DropDown/DropDown.js
@@ -193,7 +193,9 @@ class DropDown extends Component {
       value,
     } = this.props;
 
-    let ComponentType, optionProps;
+    let ComponentType,
+      optionProps,
+      dropDownLabel = label;
     if (this.props.getOptions) {
       ComponentType = Async;
       optionProps = {
@@ -202,6 +204,9 @@ class DropDown extends Component {
     } else {
       ComponentType = Select;
       optionProps = {options};
+    }
+    if (this.props.label && !required) {
+      dropDownLabel = `${label} (Optional)`;
     }
 
     const containerClasses = classNames(className);
@@ -249,7 +254,9 @@ class DropDown extends Component {
           return (
             <div className={containerClasses}>
               <div className={dropDownClasses}>
-                <label className="uic--position-absolute">{label}</label>
+                <label className="uic--position-absolute">
+                  {dropDownLabel}
+                </label>
                 <div className="uic--mcgonagall-dropdown-wrapper">
                   <ComponentType
                     {...this.props}
@@ -266,7 +273,7 @@ class DropDown extends Component {
                     isClearable={clearable}
                     isDisabled={disabled}
                     isLoading={loading}
-                    aria-label={label}
+                    aria-label={dropDownLabel}
                     menuPortalTarget={this.portal}
                     {...optionProps}
                   />

--- a/components/atoms/DropDown/DropDown.js
+++ b/components/atoms/DropDown/DropDown.js
@@ -205,7 +205,7 @@ class DropDown extends Component {
       ComponentType = Select;
       optionProps = {options};
     }
-    if (this.props.label && !required) {
+    if (label && !required) {
       dropDownLabel = `${label} (Optional)`;
     }
 

--- a/components/atoms/DropDown/DropDown.md
+++ b/components/atoms/DropDown/DropDown.md
@@ -96,3 +96,6 @@ async function getOptions(input) {
   }
 }
 ```
+
+### props.disableOptionalFlag
+If an input is _not_ marked as `required` it will show an `(Optional)` flag in the label. You can disable this behavior by setting the `disableOptionalFlag` prop to `true`.

--- a/components/atoms/DropDown/DropDown.md
+++ b/components/atoms/DropDown/DropDown.md
@@ -7,13 +7,12 @@ The DropDown component displays a series options in a dropdown list. The list ca
 You can use this component using one of the following import patterns.
 
 ```javascript
-import DropDown from '@unitedincome/components/dist/DropDown'
+import DropDown from '@unitedincome/components/dist/DropDown';
 ```
 
 ```javascript
-import {DropDown} from '@unitedincome/components'
+import {DropDown} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/DropDown/DropDown.md
+++ b/components/atoms/DropDown/DropDown.md
@@ -98,4 +98,5 @@ async function getOptions(input) {
 ```
 
 ### props.disableOptionalFlag
+
 If an input is _not_ marked as `required` it will show an `(Optional)` flag in the label. You can disable this behavior by setting the `disableOptionalFlag` prop to `true`.

--- a/components/atoms/DropDown/DropDown.scss
+++ b/components/atoms/DropDown/DropDown.scss
@@ -38,7 +38,7 @@ $focus-shadow: rgba(77, 0, 186, 0.5);
   }
 
   &.uic--disabled {
-    color: $slate;
+    color: $disabled-text;
 
     label {
       color: $disabled-text;
@@ -50,7 +50,7 @@ $focus-shadow: rgba(77, 0, 186, 0.5);
 
     .uic--mcgonagall-dropdown__control {
       border-color: $light-gray;
-      color: $slate;
+      color: $disabled-text;
 
       .uic--mcgonagall-dropdown-wrapper {
         background-color: $table-alternate;
@@ -62,7 +62,7 @@ $focus-shadow: rgba(77, 0, 186, 0.5);
       }
 
       .uic--mcgonagall-dropdown__single-value {
-        color: $slate;
+        color: $disabled-text;
       }
 
       &.uic--mcgonagall-dropdown__control--is-focused {
@@ -73,7 +73,7 @@ $focus-shadow: rgba(77, 0, 186, 0.5);
         .uic--mcgonagall-dropdown__value-container--has-value,
         .uic--mcgonagall-dropdown__single-value,
         input {
-          color: $slate !important; // Required to override react-select input styles.
+          color: $disabled-text !important; // Required to override react-select input styles.
         }
       }
     }

--- a/components/atoms/DropDown/DropDown.spec.js
+++ b/components/atoms/DropDown/DropDown.spec.js
@@ -24,7 +24,7 @@ test('DropDown - renders', (t) => {
 
   t.equal(
     component.find('label').text(),
-    'My Options',
+    'My Options (Optional)',
     'Field label is correct'
   );
 

--- a/components/atoms/DropDown/DropDown.story.js
+++ b/components/atoms/DropDown/DropDown.story.js
@@ -67,6 +67,7 @@ const store = new Store({
   selectedExample2: 'uk',
   validExample: 'invalid',
   apiExample: '',
+  disabledExampleWithValue: 'disabled',
 });
 
 stories
@@ -219,6 +220,29 @@ stories.add('disabled', () => (
           label: 'Montezuma is not the best cat',
         },
       ],
+      disabled: true,
+    })}
+  />
+));
+
+stories.add('disabled with value', () => (
+  <DropDown
+    {...defaultProps({
+      formName: 'disabledExampleWithValue',
+      label: 'Best Cat',
+      description: 'Who is the best cat?',
+      placeholder: 'Is Montezuma the best cat?',
+      options: [
+        {
+          value: 'disabled',
+          label: 'Montezuma is the best cat',
+        },
+        {
+          value: 'disabledAlso',
+          label: 'Montezuma is not the best cat',
+        },
+      ],
+      value: 'disabled',
       disabled: true,
     })}
   />

--- a/components/atoms/ExpandCollapse/ExpandCollapse.md
+++ b/components/atoms/ExpandCollapse/ExpandCollapse.md
@@ -2,19 +2,17 @@
 
 The ExpandCollapse component displays content within a drawer which can be used in conjunction with a cabinet or card.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ExpandCollapse from '@unitedincome/components/dist/ExpandCollapse'
+import ExpandCollapse from '@unitedincome/components/dist/ExpandCollapse';
 ```
 
 ```javascript
-import {ExpandCollapse} from '@unitedincome/components'
+import {ExpandCollapse} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/Input/Input.js
+++ b/components/atoms/Input/Input.js
@@ -275,6 +275,7 @@ class Input extends Component {
       append,
       prepend,
       description,
+      disableOptionalFlag,
       error,
       label,
       name,
@@ -340,7 +341,7 @@ class Input extends Component {
       InputType = MaskedInput;
     }
 
-    if (label && !required) {
+    if (label && !required && !disableOptionalFlag) {
       inputLabel = `${label} (Optional)`;
     }
 
@@ -493,6 +494,8 @@ Input.propTypes = {
   value: PropTypes.string,
   /** Boolean representing if the input value is required in a form. */
   required: PropTypes.bool,
+  /** Disables the (Optional) flag when a field is not marked as required. */
+  disableOptionalFlag: PropTypes.bool,
   /** The regex pattern that determines what input characters are allowed. Validates on form submission. */
   pattern: PropTypes.string,
   /** The max length of the input field value. */

--- a/components/atoms/Input/Input.js
+++ b/components/atoms/Input/Input.js
@@ -326,6 +326,7 @@ class Input extends Component {
     let InputType = 'input';
     let prependCharacter = prepend;
     let appendCharacter = append;
+    let inputLabel = label;
 
     if (!prependCharacter && currencyMasks.includes(this.props.mask)) {
       prependCharacter = '$';
@@ -337,6 +338,10 @@ class Input extends Component {
 
     if (this.props.mask) {
       InputType = MaskedInput;
+    }
+
+    if (label && !required) {
+      inputLabel = `${label} (Optional)`;
     }
 
     if (this.props.mask) {
@@ -419,7 +424,7 @@ class Input extends Component {
               )}
               <InputType
                 type="text"
-                aria-label={this.props.label}
+                aria-label={inputLabel}
                 autoComplete={
                   appendCharacter ? 'off' : autoComplete ? autoComplete : null
                 }
@@ -431,7 +436,7 @@ class Input extends Component {
                 }}
                 {...attrs}
               />
-              <label className="uic--position-absolute">{label}</label>
+              <label className="uic--position-absolute">{inputLabel}</label>
               {description &&
               !(showInvalidity || error || reqErrorNecessary) ? (
                 <div className="uic--description">{description}</div>
@@ -441,8 +446,7 @@ class Input extends Component {
                     ? 'Required Field'
                     : validationErrorMsg ||
                       (this.props.mask &&
-                        maskEnum[this.props.mask].validationErrorMsg) ||
-                      'Invalid'}
+                        maskEnum[this.props.mask].validationErrorMsg)}
                 </div>
               )}
             </div>

--- a/components/atoms/Input/Input.md
+++ b/components/atoms/Input/Input.md
@@ -28,3 +28,8 @@ import {Input} from '@unitedincome/components';
   value={this.state.institutionName}
 />
 ```
+
+## Props 🔧
+
+### props.disableOptionalFlag
+If an input is _not_ marked as `required` it will show an `(Optional)` flag in the label. You can disable this behavior by setting the `disableOptionalFlag` prop to `true`.

--- a/components/atoms/Input/Input.md
+++ b/components/atoms/Input/Input.md
@@ -32,4 +32,5 @@ import {Input} from '@unitedincome/components';
 ## Props 🔧
 
 ### props.disableOptionalFlag
+
 If an input is _not_ marked as `required` it will show an `(Optional)` flag in the label. You can disable this behavior by setting the `disableOptionalFlag` prop to `true`.

--- a/components/atoms/Input/Input.md
+++ b/components/atoms/Input/Input.md
@@ -7,11 +7,11 @@ The Input component renders a [HTML input element](https://developer.mozilla.org
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Input from '@unitedincome/components/dist/Input'
+import Input from '@unitedincome/components/dist/Input';
 ```
 
 ```javascript
-import {Input} from '@unitedincome/components'
+import {Input} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/Input/Input.scss
+++ b/components/atoms/Input/Input.scss
@@ -94,6 +94,12 @@ $input-data-value-color: rgba(255, 255, 255, 0);
       }
     }
 
+    &.uic--disabled {
+      &::before {
+        color: $disabled-text;
+      }
+    }
+
     &.uic--error {
       &::before {
         color: $pink;
@@ -151,6 +157,18 @@ $input-data-value-color: rgba(255, 255, 255, 0);
         color: $input-data-value-color;
         position: relative;
         z-index: 9999;
+      }
+
+      &.uic--disabled {
+        input {
+          background-color: $table-alternate;
+          position: inherit;
+          z-index: 0;
+        }
+
+        &::after {
+          color: $disabled-text;
+        }
       }
 
       &::after {

--- a/components/atoms/Input/Input.spec.js
+++ b/components/atoms/Input/Input.spec.js
@@ -31,7 +31,7 @@ test('Input - Renders props as attributes on the input', (t) => {
   t.equal(componentInputProps.value, 'VAL');
   t.equal(componentInputProps.type, 'text');
   t.equal(componentInputProps.placeholder, '$0');
-  t.equal(componentInputProps['aria-label'], 'Value');
+  t.equal(componentInputProps['aria-label'], 'Value (Optional)');
   t.equal(componentInputProps.required, undefined); // eslint-disable-line no-undefined
   t.equal(componentInputProps.pattern, '^\\d{5}$');
   t.equal(componentInputProps.maxLength, 5);

--- a/components/atoms/Input/Input.story.js
+++ b/components/atoms/Input/Input.story.js
@@ -178,3 +178,30 @@ stories.add('disabled', () => (
     value="1660 L Street"
   />
 ));
+
+stories.add('disabled', () => (
+  <Input
+    {...defaultProps({
+      formName: 'disabled',
+      label: 'Address',
+      description: 'This is where you live.',
+      placeholder: 'Enter your address...',
+      disabled: true,
+      mask: null,
+    })}
+  />
+));
+
+stories.add('disabled with value', () => (
+  <Input
+    {...defaultProps({
+      formName: 'disabled',
+      label: 'Address',
+      description: 'This is where you live.',
+      placeholder: 'Enter your address...',
+      disabled: true,
+      mask: null,
+    })}
+    value="1660 L Street"
+  />
+));

--- a/components/atoms/ItemizationWidget/ItemizationWidget.md
+++ b/components/atoms/ItemizationWidget/ItemizationWidget.md
@@ -7,11 +7,11 @@ Displays a widget which itemizes and sums totals. Turns into collapsible menu on
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ItemizationWidget from '@unitedincome/components/dist/ItemizationWidget'
+import ItemizationWidget from '@unitedincome/components/dist/ItemizationWidget';
 ```
 
 ```javascript
-import {ItemizationWidget} from '@unitedincome/components'
+import {ItemizationWidget} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/Loader/Loader.md
+++ b/components/atoms/Loader/Loader.md
@@ -7,11 +7,11 @@ The Loader component displays a bouncing United Income logo to indicate that the
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Loader from '@unitedincome/components/dist/Loader'
+import Loader from '@unitedincome/components/dist/Loader';
 ```
 
 ```javascript
-import {Loader} from '@unitedincome/components'
+import {Loader} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/OptionBox/OptionBox.md
+++ b/components/atoms/OptionBox/OptionBox.md
@@ -7,13 +7,12 @@ The OptionBox component displays an option box which can be used in either selec
 You can use this component using one of the following import patterns.
 
 ```javascript
-import OptionBox from '@unitedincome/components/dist/OptionBox'
+import OptionBox from '@unitedincome/components/dist/OptionBox';
 ```
 
 ```javascript
-import {OptionBox} from '@unitedincome/components'
+import {OptionBox} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/Ranking/Ranking.md
+++ b/components/atoms/Ranking/Ranking.md
@@ -7,11 +7,11 @@ The Ranking component renders an ordered list with clickable buttons and drag an
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Ranking from '@unitedincome/components/dist/Ranking'
+import Ranking from '@unitedincome/components/dist/Ranking';
 ```
 
 ```javascript
-import {Ranking} from '@unitedincome/components'
+import {Ranking} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/Slider/Slider.md
+++ b/components/atoms/Slider/Slider.md
@@ -2,17 +2,16 @@
 
 The Slider component creates an interactive range slider between 1 and 10.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Slider from '@unitedincome/components/dist/Slider'
+import Slider from '@unitedincome/components/dist/Slider';
 ```
 
 ```javascript
-import {Slider} from '@unitedincome/components'
+import {Slider} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/Spinner/Spinner.md
+++ b/components/atoms/Spinner/Spinner.md
@@ -2,17 +2,16 @@
 
 The Spinner component displays a spinning SVG to indicate that something is loading.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Spinner from '@unitedincome/components/dist/Spinner'
+import Spinner from '@unitedincome/components/dist/Spinner';
 ```
 
 ```javascript
-import {Spinner} from '@unitedincome/components'
+import {Spinner} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/StackableExpandCollapse/StackableExpandCollapse.md
+++ b/components/atoms/StackableExpandCollapse/StackableExpandCollapse.md
@@ -2,17 +2,16 @@
 
 Display content within a box which can be expanded to display the child content or collapsed to hide it.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import StackableExpandCollapse from '@unitedincome/components/dist/StackableExpandCollapse'
+import StackableExpandCollapse from '@unitedincome/components/dist/StackableExpandCollapse';
 ```
 
 ```javascript
-import {StackableExpandCollapse} from '@unitedincome/components'
+import {StackableExpandCollapse} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/Tooltip/Tooltip.md
+++ b/components/atoms/Tooltip/Tooltip.md
@@ -7,11 +7,11 @@ Attaches a tooltip to a link or button on hover or press.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Tooltip from '@unitedincome/components/dist/Tooltip'
+import Tooltip from '@unitedincome/components/dist/Tooltip';
 ```
 
 ```javascript
-import {Tooltip} from '@unitedincome/components'
+import {Tooltip} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/icons/ArrowEllipsisIcon/ArrowEllipsisIcon.md
+++ b/components/atoms/icons/ArrowEllipsisIcon/ArrowEllipsisIcon.md
@@ -2,19 +2,17 @@
 
 The ArrowEllipsisIcon component creates an arrow icon using inline SVG.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ArrowEllipsisIcon from '@unitedincome/components/dist/ArrowEllipsisIcon'
+import ArrowEllipsisIcon from '@unitedincome/components/dist/ArrowEllipsisIcon';
 ```
 
 ```javascript
-import {ArrowEllipsisIcon} from '@unitedincome/components'
+import {ArrowEllipsisIcon} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/icons/ArrowIcon/ArrowIcon.md
+++ b/components/atoms/icons/ArrowIcon/ArrowIcon.md
@@ -2,19 +2,17 @@
 
 The ArrowIcon component creates an arrow icon using inline SVG.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ArrowIcon from '@unitedincome/components/dist/ArrowIcon'
+import ArrowIcon from '@unitedincome/components/dist/ArrowIcon';
 ```
 
 ```javascript
-import {ArrowIcon} from '@unitedincome/components'
+import {ArrowIcon} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/icons/CaretIcon/CaretIcon.md
+++ b/components/atoms/icons/CaretIcon/CaretIcon.md
@@ -2,19 +2,17 @@
 
 The CaretIcon component creates an caret icon using inline SVG.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import CaretIcon from '@unitedincome/components/dist/CaretIcon'
+import CaretIcon from '@unitedincome/components/dist/CaretIcon';
 ```
 
 ```javascript
-import {CaretIcon} from '@unitedincome/components'
+import {CaretIcon} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/icons/ClearIcon/ClearIcon.md
+++ b/components/atoms/icons/ClearIcon/ClearIcon.md
@@ -2,19 +2,17 @@
 
 The ClearIcon component creates a clear icon using inline SVG.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ClearIcon from '@unitedincome/components/dist/ClearIcon'
+import ClearIcon from '@unitedincome/components/dist/ClearIcon';
 ```
 
 ```javascript
-import {ClearIcon} from '@unitedincome/components'
+import {ClearIcon} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/icons/CloseIcon/CloseIcon.md
+++ b/components/atoms/icons/CloseIcon/CloseIcon.md
@@ -7,13 +7,12 @@ The CloseIcon component creates a close icon using inline SVG.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import CloseIcon from '@unitedincome/components/dist/CloseIcon'
+import CloseIcon from '@unitedincome/components/dist/CloseIcon';
 ```
 
 ```javascript
-import {CloseIcon} from '@unitedincome/components'
+import {CloseIcon} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/icons/ErrorFlagIcon/ErrorFlagIcon.md
+++ b/components/atoms/icons/ErrorFlagIcon/ErrorFlagIcon.md
@@ -7,13 +7,12 @@ The ErrorFlagIcon component creates an error flag icon using inline SVG.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ErrorFlagIcon from '@unitedincome/components/dist/ErrorFlagIcon'
+import ErrorFlagIcon from '@unitedincome/components/dist/ErrorFlagIcon';
 ```
 
 ```javascript
-import {ErrorFlagIcon} from '@unitedincome/components'
+import {ErrorFlagIcon} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/icons/ExpandyCircleIcon/ExpandyCircleIcon.md
+++ b/components/atoms/icons/ExpandyCircleIcon/ExpandyCircleIcon.md
@@ -1,4 +1,4 @@
-# ExpandyCircleIcon 
+# ExpandyCircleIcon
 
 The ExpandyCircleIcon component creates an arrow icon using inline SVG.
 
@@ -7,11 +7,11 @@ The ExpandyCircleIcon component creates an arrow icon using inline SVG.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ExpandyCircleIcon from '@unitedincome/components/dist/ExpandyCircleIcon'
+import ExpandyCircleIcon from '@unitedincome/components/dist/ExpandyCircleIcon';
 ```
 
 ```javascript
-import {ExpandyCircleIcon} from '@unitedincome/components'
+import {ExpandyCircleIcon} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/icons/StarIcon/StarIcon.md
+++ b/components/atoms/icons/StarIcon/StarIcon.md
@@ -7,13 +7,12 @@ The StarIcon component creates an arrow icon using inline SVG.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import StarIcon from '@unitedincome/components/dist/StarIcon'
+import StarIcon from '@unitedincome/components/dist/StarIcon';
 ```
 
 ```javascript
-import {StarIcon} from '@unitedincome/components'
+import {StarIcon} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/icons/TrashIcon/TrashIcon.md
+++ b/components/atoms/icons/TrashIcon/TrashIcon.md
@@ -7,13 +7,12 @@ The TrashIcon component creates a trash icon using inline SVG.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import TrashIcon from '@unitedincome/components/dist/TrashIcon'
+import TrashIcon from '@unitedincome/components/dist/TrashIcon';
 ```
 
 ```javascript
-import {TrashIcon} from '@unitedincome/components'
+import {TrashIcon} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/illustrations/AccountCircleIllustration/AccountCircleIllustration.md
+++ b/components/atoms/illustrations/AccountCircleIllustration/AccountCircleIllustration.md
@@ -7,13 +7,12 @@ The AccountCircleIllustration component creates an account illuminator using inl
 You can use this component using one of the following import patterns.
 
 ```javascript
-import AccountCircleIllustration from '@unitedincome/components/dist/AccountCircleIllustration'
+import AccountCircleIllustration from '@unitedincome/components/dist/AccountCircleIllustration';
 ```
 
 ```javascript
-import {AccountCircleIllustration} from '@unitedincome/components'
+import {AccountCircleIllustration} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/illustrations/GiftCircleIllustration/GiftCircleIllustration.md
+++ b/components/atoms/illustrations/GiftCircleIllustration/GiftCircleIllustration.md
@@ -7,13 +7,12 @@ The GiftCircleIllustration component creates a gift illuminator using inline SVG
 You can use this component using one of the following import patterns.
 
 ```javascript
-import GiftCircleIllustration from '@unitedincome/components/dist/GiftCircleIllustration'
+import GiftCircleIllustration from '@unitedincome/components/dist/GiftCircleIllustration';
 ```
 
 ```javascript
-import {GiftCircleIllustration} from '@unitedincome/components'
+import {GiftCircleIllustration} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/atoms/illustrations/GivingCircleIllustration/GivingCircleIllustration.md
+++ b/components/atoms/illustrations/GivingCircleIllustration/GivingCircleIllustration.md
@@ -2,17 +2,16 @@
 
 The GivingCircleIllustration component creates a giving hand illuminator using inline SVG.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import GivingCircleIllustration from '@unitedincome/components/dist/GivingCircleIllustration'
+import GivingCircleIllustration from '@unitedincome/components/dist/GivingCircleIllustration';
 ```
 
 ```javascript
-import {GivingCircleIllustration} from '@unitedincome/components'
+import {GivingCircleIllustration} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/illustrations/HealthCircleIllustration/HealthCircleIllustration.md
+++ b/components/atoms/illustrations/HealthCircleIllustration/HealthCircleIllustration.md
@@ -2,17 +2,16 @@
 
 The HealthCircleIllustration component creates a health illuminator using inline SVG.
 
-
 ## Importing 📦
 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import HealthCircleIllustration from '@unitedincome/components/dist/HealthCircleIllustration'
+import HealthCircleIllustration from '@unitedincome/components/dist/HealthCircleIllustration';
 ```
 
 ```javascript
-import {HealthCircleIllustration} from '@unitedincome/components'
+import {HealthCircleIllustration} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/illustrations/HomeCircleIllustration/HomeCircleIllustration.md
+++ b/components/atoms/illustrations/HomeCircleIllustration/HomeCircleIllustration.md
@@ -7,11 +7,11 @@ The HomeCircleIllustration component creates a home illuminator using inline SVG
 You can use this component using one of the following import patterns.
 
 ```javascript
-import HomeCircleIllustration from '@unitedincome/components/dist/HomeCircleIllustration'
+import HomeCircleIllustration from '@unitedincome/components/dist/HomeCircleIllustration';
 ```
 
 ```javascript
-import {HomeCircleIllustration} from '@unitedincome/components'
+import {HomeCircleIllustration} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/illustrations/IncomeCircleIllustration/IncomeCircleIllustration.md
+++ b/components/atoms/illustrations/IncomeCircleIllustration/IncomeCircleIllustration.md
@@ -7,11 +7,11 @@ The IncomeCircleIllustration component creates an income illuminator using inlin
 You can use this component using one of the following import patterns.
 
 ```javascript
-import IncomeCircleIllustration from '@unitedincome/components/dist/IncomeCircleIllustration'
+import IncomeCircleIllustration from '@unitedincome/components/dist/IncomeCircleIllustration';
 ```
 
 ```javascript
-import {IncomeCircleIllustration} from '@unitedincome/components'
+import {IncomeCircleIllustration} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/illustrations/LampCircleIllustration/LampCircleIllustration.md
+++ b/components/atoms/illustrations/LampCircleIllustration/LampCircleIllustration.md
@@ -7,11 +7,11 @@ The LampCircleIllustration component creates a lamp illuminator using inline SVG
 You can use this component using one of the following import patterns.
 
 ```javascript
-import LampCircleIllustration from '@unitedincome/components/dist/LampCircleIllustration'
+import LampCircleIllustration from '@unitedincome/components/dist/LampCircleIllustration';
 ```
 
 ```javascript
-import {LampCircleIllustration} from '@unitedincome/components'
+import {LampCircleIllustration} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/illustrations/MedicareCircleIllustration/MedicareCircleIllustration.md
+++ b/components/atoms/illustrations/MedicareCircleIllustration/MedicareCircleIllustration.md
@@ -7,11 +7,11 @@ The MedicareCircleIllustration component creates a Medicare illuminator using in
 You can use this component using one of the following import patterns.
 
 ```javascript
-import MedicareCircleIllustration from '@unitedincome/components/dist/MedicareCircleIllustration'
+import MedicareCircleIllustration from '@unitedincome/components/dist/MedicareCircleIllustration';
 ```
 
 ```javascript
-import {MedicareCircleIllustration} from '@unitedincome/components'
+import {MedicareCircleIllustration} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/illustrations/ProfileCircleIllustration/ProfileCircleIllustration.md
+++ b/components/atoms/illustrations/ProfileCircleIllustration/ProfileCircleIllustration.md
@@ -7,11 +7,11 @@ The ProfileCircleIllustration component creates a profile illuminator using inli
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ProfileCircleIllustration from '@unitedincome/components/dist/ProfileCircleIllustration'
+import ProfileCircleIllustration from '@unitedincome/components/dist/ProfileCircleIllustration';
 ```
 
 ```javascript
-import {ProfileCircleIllustration} from '@unitedincome/components'
+import {ProfileCircleIllustration} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/illustrations/RamenCircleIllustration/RamenCircleIllustration.md
+++ b/components/atoms/illustrations/RamenCircleIllustration/RamenCircleIllustration.md
@@ -7,11 +7,11 @@ The RamenCircleIllustration component creates a Ramen illuminator using inline S
 You can use this component using one of the following import patterns.
 
 ```javascript
-import RamenCircleIllustration from '@unitedincome/components/dist/RamenCircleIllustration'
+import RamenCircleIllustration from '@unitedincome/components/dist/RamenCircleIllustration';
 ```
 
 ```javascript
-import {RamenCircleIllustration} from '@unitedincome/components'
+import {RamenCircleIllustration} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/atoms/illustrations/ShoppingCircleIllustration/ShoppingCircleIllustration.md
+++ b/components/atoms/illustrations/ShoppingCircleIllustration/ShoppingCircleIllustration.md
@@ -7,11 +7,11 @@ The ShoppingCircleIllustration component creates a shopping illuminator using in
 You can use this component using one of the following import patterns.
 
 ```javascript
-import ShoppingCircleIllustration from '@unitedincome/components/dist/ShoppingCircleIllustration'
+import ShoppingCircleIllustration from '@unitedincome/components/dist/ShoppingCircleIllustration';
 ```
 
 ```javascript
-import {ShoppingCircleIllustration} from '@unitedincome/components'
+import {ShoppingCircleIllustration} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/molecules/Cabinet/Cabinet.md
+++ b/components/molecules/Cabinet/Cabinet.md
@@ -7,11 +7,11 @@ The Cabinet component generates a cabinet pullout which appears on the right sid
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Cabinet from '@unitedincome/components/dist/Cabinet'
+import Cabinet from '@unitedincome/components/dist/Cabinet';
 ```
 
 ```javascript
-import {Cabinet} from '@unitedincome/components'
+import {Cabinet} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/molecules/CardShell/CardShell.md
+++ b/components/molecules/CardShell/CardShell.md
@@ -7,11 +7,11 @@ This component is a flexible shell for the McGonagall card. See if any of the ot
 You can use this component using one of the following import patterns.
 
 ```javascript
-import CardShell from '@unitedincome/components/dist/CardShell'
+import CardShell from '@unitedincome/components/dist/CardShell';
 ```
 
 ```javascript
-import {CardShell} from '@unitedincome/components'
+import {CardShell} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/molecules/CardShell/CardShell.scss
+++ b/components/molecules/CardShell/CardShell.scss
@@ -117,4 +117,9 @@ $active-border-size: 4px;
       top: 0;
     }
   }
+
+  .uic--mcgonagall-dropdown,
+  .uic--mcgonagall-input {
+    padding-bottom: 1.5rem;
+  }
 }

--- a/components/molecules/CardSummaries/FormSummary/FormSummary.md
+++ b/components/molecules/CardSummaries/FormSummary/FormSummary.md
@@ -7,11 +7,11 @@ This component renders a summary for form questions and can also display groups 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import FormSummary from '@unitedincome/components/dist/FormSummary'
+import FormSummary from '@unitedincome/components/dist/FormSummary';
 ```
 
 ```javascript
-import {FormSummary} from '@unitedincome/components'
+import {FormSummary} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/molecules/CardSummaries/IncompleteSummary/IncompleteSummary.md
+++ b/components/molecules/CardSummaries/IncompleteSummary/IncompleteSummary.md
@@ -7,11 +7,11 @@ This component renders an incomplete summary that tells the user this step still
 You can use this component using one of the following import patterns.
 
 ```javascript
-import IncompleteSummary from '@unitedincome/components/dist/IncompleteSummary'
+import IncompleteSummary from '@unitedincome/components/dist/IncompleteSummary';
 ```
 
 ```javascript
-import {IncompleteSummary} from '@unitedincome/components'
+import {IncompleteSummary} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/molecules/CardSummaries/SimpleSummary/SimpleSummary.md
+++ b/components/molecules/CardSummaries/SimpleSummary/SimpleSummary.md
@@ -7,11 +7,11 @@ This component renders a simple summary to be used with a card component when it
 You can use this component using one of the following import patterns.
 
 ```javascript
-import SimpleSummary from '@unitedincome/components/dist/SimpleSummary'
+import SimpleSummary from '@unitedincome/components/dist/SimpleSummary';
 ```
 
 ```javascript
-import {SimpleSummary} from '@unitedincome/components'
+import {SimpleSummary} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/molecules/Checkboxes/Checkboxes.md
+++ b/components/molecules/Checkboxes/Checkboxes.md
@@ -7,11 +7,11 @@ The Checkboxes component renders a group of HTML select buttons with a number of
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Checkboxes from '@unitedincome/components/dist/Checkboxes'
+import Checkboxes from '@unitedincome/components/dist/Checkboxes';
 ```
 
 ```javascript
-import {Checkboxes} from '@unitedincome/components'
+import {Checkboxes} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/molecules/Modal/Modal.md
+++ b/components/molecules/Modal/Modal.md
@@ -7,11 +7,11 @@ The Modal component generates a full screen prompt to the user.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Modal from '@unitedincome/components/dist/Modal'
+import Modal from '@unitedincome/components/dist/Modal';
 ```
 
 ```javascript
-import {Modal} from '@unitedincome/components'
+import {Modal} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/molecules/RadioButtons/RadioButtons.md
+++ b/components/molecules/RadioButtons/RadioButtons.md
@@ -7,11 +7,11 @@ The RadioButton component renders a group of HTML radio buttons with a number of
 You can use this component using one of the following import patterns.
 
 ```javascript
-import RadioButtons from '@unitedincome/components/dist/RadioButtons'
+import RadioButtons from '@unitedincome/components/dist/RadioButtons';
 ```
 
 ```javascript
-import {RadioButtons} from '@unitedincome/components'
+import {RadioButtons} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/molecules/TooltipInput/TooltipInput.md
+++ b/components/molecules/TooltipInput/TooltipInput.md
@@ -7,11 +7,11 @@ Wraps an Input field in a Tooltip component which activates on key press. Unlike
 You can use this component using one of the following import patterns.
 
 ```javascript
-import TooltipInput from '@unitedincome/components/dist/TooltipInput'
+import TooltipInput from '@unitedincome/components/dist/TooltipInput';
 ```
 
 ```javascript
-import {TooltipInput} from '@unitedincome/components'
+import {TooltipInput} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/organisms-complex/CheckboxCard/CheckboxCard.md
+++ b/components/organisms-complex/CheckboxCard/CheckboxCard.md
@@ -9,11 +9,11 @@ The collapsed state of this card uses the Simple Summary component.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import CheckboxCard from '@unitedincome/components/dist/CheckboxCard'
+import CheckboxCard from '@unitedincome/components/dist/CheckboxCard';
 ```
 
 ```javascript
-import {CheckboxCard} from '@unitedincome/components'
+import {CheckboxCard} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/organisms-complex/InputCard/InputCard.md
+++ b/components/organisms-complex/InputCard/InputCard.md
@@ -9,11 +9,11 @@ The collapsed state of this card uses the Simple Summary component.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import InputCard from '@unitedincome/components/dist/InputCard'
+import InputCard from '@unitedincome/components/dist/InputCard';
 ```
 
 ```javascript
-import {InputCard} from '@unitedincome/components'
+import {InputCard} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/organisms-complex/RadioButtonCard/RadioButtonCard.md
+++ b/components/organisms-complex/RadioButtonCard/RadioButtonCard.md
@@ -9,11 +9,11 @@ The collapsed state of this card uses the Simple Summary component.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import RadioButtonCard from '@unitedincome/components/dist/RadioButtonCard'
+import RadioButtonCard from '@unitedincome/components/dist/RadioButtonCard';
 ```
 
 ```javascript
-import {RadioButtonCard} from '@unitedincome/components'
+import {RadioButtonCard} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/organisms-complex/RankingCard/RankingCard.md
+++ b/components/organisms-complex/RankingCard/RankingCard.md
@@ -9,11 +9,11 @@ The collapsed state of this card uses the Simple Summary component.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import RankingCard from '@unitedincome/components/dist/RankingCard'
+import RankingCard from '@unitedincome/components/dist/RankingCard';
 ```
 
 ```javascript
-import {RankingCard} from '@unitedincome/components'
+import {RankingCard} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/organisms-complex/SliderCard/SliderCard.md
+++ b/components/organisms-complex/SliderCard/SliderCard.md
@@ -9,13 +9,12 @@ The collapsed state of this card uses the Simple Summary component.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import SliderCard from '@unitedincome/components/dist/SliderCard'
+import SliderCard from '@unitedincome/components/dist/SliderCard';
 ```
 
 ```javascript
-import {SliderCard} from '@unitedincome/components'
+import {SliderCard} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/organisms-simple/CompletionScreen/CompletionScreen.md
+++ b/components/organisms-simple/CompletionScreen/CompletionScreen.md
@@ -7,13 +7,12 @@ This component renders the completion screen for the McGonagall flow. It should 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import CompletionScreen from '@unitedincome/components/dist/CompletionScreen'
+import CompletionScreen from '@unitedincome/components/dist/CompletionScreen';
 ```
 
 ```javascript
-import {CompletionScreen} from '@unitedincome/components'
+import {CompletionScreen} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/organisms-simple/MessageCard/MessageCard.md
+++ b/components/organisms-simple/MessageCard/MessageCard.md
@@ -7,13 +7,12 @@ This component renders a message card for the Hogwarts/McGonagall flow used for 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import MessageCard from '@unitedincome/components/dist/MessageCard'
+import MessageCard from '@unitedincome/components/dist/MessageCard';
 ```
 
 ```javascript
-import {MessageCard} from '@unitedincome/components'
+import {MessageCard} from '@unitedincome/components';
 ```
-
 
 ## Example 🚀
 

--- a/components/organisms-simple/QuestionCard/QuestionCard.md
+++ b/components/organisms-simple/QuestionCard/QuestionCard.md
@@ -7,11 +7,11 @@ This component renders a question card for the Hogwarts/McGonagall flow.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import QuestionCard from '@unitedincome/components/dist/QuestionCard'
+import QuestionCard from '@unitedincome/components/dist/QuestionCard';
 ```
 
 ```javascript
-import {QuestionCard} from '@unitedincome/components'
+import {QuestionCard} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/organisms-simple/QuestionCard/QuestionCard.story.js
+++ b/components/organisms-simple/QuestionCard/QuestionCard.story.js
@@ -11,13 +11,20 @@ import ExpandCollapse from '~components/atoms/ExpandCollapse/ExpandCollapse';
 import OptionBox from '~components/atoms/OptionBox/OptionBox';
 import QuestionCardReadme from './QuestionCard.md';
 import Input from '~components/atoms/Input/Input';
+import DropDown from '~components/atoms/DropDown/DropDown';
 
 const stories = storiesOf('Simple Organisms/QuestionCard', module);
 
 const store = new Store({
   yesNo: '',
   input: '',
+  from: 'capitalOne',
+  frequency: 'monthly',
+  startDate: '05/31/2019',
+  endDate: '07/20/202',
   disabled: false,
+  interest: '100',
+  catTax: '1337',
 });
 
 stories
@@ -53,7 +60,6 @@ const defaultProps = (
     label: 'Show more details',
     cabinetContent: (
       <div>
-        <h1>Montezuma is the best</h1>
         <p>Hello this is the cabinet and yes, Montezuma is the best.</p>
       </div>
     ),
@@ -112,6 +118,109 @@ stories.add('active', () => (
         ]}
         value={store.get('yesNo')}
         key="yesNo"
+      />
+    </QuestionCard>
+  </MemoryRouter>
+));
+
+stories.add('active with simple form', () => (
+  <MemoryRouter key="question">
+    <QuestionCard {...defaultProps(false)}>
+      <DropDown
+        name="from"
+        options={[
+          {
+            value: 'capitalOne',
+            label: 'Capital One Checking ...7890 ($3,234.567.89)',
+          },
+          {
+            value: 'chase',
+            label: 'Chase Savings ...1127 ($999,999.00)',
+          },
+        ]}
+        onChange={(name, value) => store.set({[name]: value})}
+        value={store.get('from')}
+        label="From"
+        required={false}
+      />
+      <DropDown
+        name="to"
+        options={[
+          {
+            value: 'unitedIncome',
+            label: 'United Income Brokerage ...5428 ($2,345,678.89)',
+          },
+          {
+            value: 'montezuma',
+            label: 'Bank of Montezuma ...1337 ($9,999,999.99)',
+          },
+        ]}
+        value="montezuma"
+        disabled={true}
+        description="The acount to transfer the money to."
+        label="To"
+      />
+
+      <div className="uic--row">
+        <div className="uic--col-6">
+          <Input
+            name="interest"
+            label="Additional Interest"
+            mask="PercentageWithDecimal"
+            onChange={(name, value) => store.set({[name]: value})}
+            value={store.get('interest')}
+            disabled={true}
+          />
+        </div>
+
+        <div className="uic--col-6">
+          <Input
+            name="catTax"
+            label="Cat Tax"
+            mask="Currency"
+            onChange={(name, value) => store.set({[name]: value})}
+            value={store.get('catTax')}
+            disabled={true}
+          />
+        </div>
+      </div>
+
+      <DropDown
+        name="frequency"
+        options={[
+          {
+            value: 'monthly',
+            label: 'Monthly',
+          },
+          {
+            value: 'yearly',
+            label: 'Yearly',
+          },
+          {
+            value: 'quarterly',
+            label: 'Quarterly',
+          },
+        ]}
+        onChange={(name, value) => store.set({[name]: value})}
+        value={store.get('frequency')}
+        label="Frequency"
+        required={false}
+      />
+
+      <Input
+        name="startDate"
+        label="Start Date"
+        mask="Date"
+        value={store.get('startDate')}
+        onChange={(name, value) => store.set({[name]: value})}
+      />
+
+      <Input
+        name="endDate"
+        label="End Date"
+        mask="Date"
+        value={store.get('endDate')}
+        validationErrorMsg="Must follow the format mm/dd/yyyy."
       />
     </QuestionCard>
   </MemoryRouter>

--- a/components/templates/McGonagall/McGonagall.md
+++ b/components/templates/McGonagall/McGonagall.md
@@ -7,13 +7,12 @@ McGonagall is the successor to the Hogwarts framework that we initially used to 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import McGonagall from '@unitedincome/components/dist/McGonagall'
+import McGonagall from '@unitedincome/components/dist/McGonagall';
 ```
 
 ```javascript
-import {McGonagall} from '@unitedincome/components'
+import {McGonagall} from '@unitedincome/components';
 ```
-
 
 ## Quick Start
 

--- a/components/utilities/Confirm/Confirm.md
+++ b/components/utilities/Confirm/Confirm.md
@@ -7,11 +7,11 @@ Allows you to call a confirmation modal similar to how you use `window.confirm`.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Confirm from '@unitedincome/components/dist/Confirm'
+import Confirm from '@unitedincome/components/dist/Confirm';
 ```
 
 ```javascript
-import {Confirm} from '@unitedincome/components'
+import {Confirm} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/utilities/DateUtils/DateUtils.md
+++ b/components/utilities/DateUtils/DateUtils.md
@@ -7,11 +7,11 @@ Date utility functions for things such as input validation.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import DateUtils from '@unitedincome/components/dist/DateUtils'
+import DateUtils from '@unitedincome/components/dist/DateUtils';
 ```
 
 ```javascript
-import {DateUtils} from '@unitedincome/components'
+import {DateUtils} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/utilities/DetectBrowser/DetectBrowser.md
+++ b/components/utilities/DetectBrowser/DetectBrowser.md
@@ -7,11 +7,11 @@ Higher order component that detects the current browser the user is using.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import detectBrowser from '@unitedincome/components/dist/detectBrowser'
+import detectBrowser from '@unitedincome/components/dist/detectBrowser';
 ```
 
 ```javascript
-import {detectBrowser} from '@unitedincome/components'
+import {detectBrowser} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/utilities/FormatUtils/FormatUtils.md
+++ b/components/utilities/FormatUtils/FormatUtils.md
@@ -7,11 +7,11 @@ Format utility functions for things such as currency, dates, etc.
 You can use this component using one of the following import patterns.
 
 ```javascript
-import FormatUtils from '@unitedincome/components/dist/FormatUtils'
+import FormatUtils from '@unitedincome/components/dist/FormatUtils';
 ```
 
 ```javascript
-import {FormatUtils} from '@unitedincome/components'
+import {FormatUtils} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/components/utilities/Portal/Portal.md
+++ b/components/utilities/Portal/Portal.md
@@ -7,11 +7,11 @@ Creates a [React Portal](https://reactjs.org/docs/portals.html) which pulls DOM 
 You can use this component using one of the following import patterns.
 
 ```javascript
-import Portal from '@unitedincome/components/dist/Portal'
+import Portal from '@unitedincome/components/dist/Portal';
 ```
 
 ```javascript
-import {Portal} from '@unitedincome/components'
+import {Portal} from '@unitedincome/components';
 ```
 
 ## Example 🚀

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "testSingle": "NODE_ENV=test tape -r @babel/register -r ./utils-for-tests/configureEnzyme.js -r jsdom-global/register -r ignore-styles",
     "buildStorybook": "build-storybook -c .storybook -o .build",
     "publishStorybook": "yarn buildStorybook && ./publishStorybook.sh",
-    "lint": "eslint './components/**/*.js' './proptypes/**/*.js' './.storybook/*.js' --cache && sass-lint -v -q && prettier -l './components/**/*.js' './proptypes/**/*.js' && prettier -l './components/**/*.scss' './constants/sass/**/*.scss' './constants/sass/*.scss' --parser=scss || (echo need formatting, use yarn format ; exit 1)",
+    "lint": "eslint './components/**/*.js' './proptypes/**/*.js' './.storybook/*.js' --cache && sass-lint -v -q && prettier -l './components/**/*.js' './proptypes/**/*.js' && prettier -l './components/**/*.md' './*.md' --parser=markdown && prettier -l './components/**/*.scss' './constants/sass/**/*.scss' './constants/sass/*.scss' --parser=scss || (echo need formatting, use yarn format ; exit 1)",
     "format": "prettier --write './components/**/*.js' './proptypes/**/*.js' './.storybook/*.js' && prettier --write  './components/**/*.md' './*.md' --parser=markdown && sass-lint-auto-fix && prettier --write './components/**/*.scss' './constants/sass/**/*.scss' './constants/sass/*.scss' --parser=scss",
     "generate": "yarn hygen component new",
     "browserstack": "yarn nightwatch -c nightwatch/config.js"


### PR DESCRIPTION
### Description
> Please provide a brief description of your changes below.

Couple of changes here...

* Formatted all markdown files with Prettier (for some reason this didn't happen before?)
* Made spacing consistent between all dropdown and input fields in a card. Should be 1.5rems between (This matches the Bootstrap grid, Monique has approved the spacing)
* Added `(Optional)` to inputs which are not marked as disabled in their label.
* Staged a QuestionCard story which matches this comp: https://app.zeplin.io/project/589b5c319e603a741d558f10/screen/5c7e7201429b3a6274bb644a
* Fixed an issue with the Input and DropDown field's disabled styles. They were not getting the correct styles if they were disabled *with* a value, I've fixed it and added a story which shows this state.

### Testing Instructions
> What should be done in order to test this pull request, or re-create its effects.

Look at them in Storybook, everything should be happy days.

### Comments
> Any additional comments that will aid with the review process.

- [JIRA Ticket](https://unitedincome.atlassian.net/browse/app-2917)