### PR TITLE
Add optional group key to form summary

### DIFF
--- a/components/molecules/CardSummaries/FormSummary/FormSummary.js
+++ b/components/molecules/CardSummaries/FormSummary/FormSummary.js
@@ -26,7 +26,7 @@ const FormSummary = ({shortTitle, editCard, answerGroups, to}) => {
         </div>
       </div>
       {answerGroups.map((group, index) => {
-        const key = group.groupName || `${shortTitle}-${index}`;
+        const key = group.key || group.groupName || `${shortTitle}-${index}`;
 
         const groupClass = classNames({
           'uic--card-summary': true,

--- a/components/molecules/CardSummaries/FormSummary/FormSummary.js
+++ b/components/molecules/CardSummaries/FormSummary/FormSummary.js
@@ -65,6 +65,8 @@ FormSummary.propTypes = {
   /** An array of objects containing the groups of answers to display. The object is broken down below. */
   answerGroups: PropTypes.arrayOf(
     PropTypes.shape({
+      /** The React key to use for the group of data */
+      key: PropTypes.string,
       /** The name of the group of data */
       groupName: PropTypes.string,
       /** An array of objects containing the answers for the group. The object is broken down below. */

--- a/components/molecules/CardSummaries/FormSummary/FormSummary.spec.js
+++ b/components/molecules/CardSummaries/FormSummary/FormSummary.spec.js
@@ -46,6 +46,7 @@ test('FormSummary - Renders one answer', (t) => {
       shortTitle="This is a simpler question"
       answerGroups={[
         {
+          key: 'group0',
           groupName: 'group',
           answers: [
             {label: 'From', value: 'Bank of America Checking…8765'},
@@ -54,7 +55,7 @@ test('FormSummary - Renders one answer', (t) => {
           ],
         },
         {
-          groupName: 'group1',
+          groupName: 'group',
           answers: [
             {label: 'From', value: 'Bank of America Checking…8765'},
             {label: 'To', value: 'United Income Brokerage…2653'},


### PR DESCRIPTION
### Description
The form summary component uses the group names as the React keys (see [here](https://github.com/UnitedIncome/components/blob/1d99ad2afdecd07e3a0e12217f12250a53df15a1/components/molecules/CardSummaries/FormSummary/FormSummary.js#L29))--which causes warnings if you have duplicate group names:
![form-summary](https://user-images.githubusercontent.com/1727145/61554177-4e44f080-aa2a-11e9-8859-452470aa435a.png)
![warning](https://user-images.githubusercontent.com/1727145/61554363-c3182a80-aa2a-11e9-8e85-685a82e8f69f.png)

This PR allows answer groups to specify an optional key to use as the React key.

### Testing Instructions
Render a form summary with two answer groups that have the same name--there will be a React warning. Add a unique key name to one or both of the answer groups and re-render--there will not be a React warning.