### PR TITLE
Remove unused hideButton prop from QuestionCard

### DIFF
--- a/components/organisms-simple/QuestionCard/QuestionCard.js
+++ b/components/organisms-simple/QuestionCard/QuestionCard.js
@@ -146,8 +146,6 @@ QuestionCard.propTypes = {
   hasError: PropTypes.bool,
   /** If changes have been made */
   hasMadeChanges: PropTypes.bool,
-  /** Hides the button. */
-  hideButton: PropTypes.bool,
   /** Shows the collapsed state of the card which switches the content to the summary. */
   isCollapsed: PropTypes.bool,
   /** Whether this is the furthest step. if this and isCollapsed is true, this will collapse to the incomplete summary/ */

--- a/components/organisms-simple/QuestionCard/QuestionCard.story.js
+++ b/components/organisms-simple/QuestionCard/QuestionCard.story.js
@@ -50,7 +50,6 @@ const defaultProps = (
   disabled: boolean('disabled', false),
   hasError: boolean('hasError', false),
   hasMadeChanges: boolean('hasMadeChanges', true),
-  hideButton: boolean('hideButton', false),
   isCollapsed: boolean('isCollapsed', isCollapsed),
   isLatestCard: boolean('isLatestCard', isLatestCard),
   isFetching: boolean('isFetching', false),


### PR DESCRIPTION
### Description
The `hideButton` prop defined for `QuestionCard` has no effect. This PR removes the prop type and story knob for `hideButton` from `QuestionCard`.