### PR TITLE
Percentagewithoutdecimal mask

### DIFF
--- a/components/atoms/Input/Input.masks.jsx
+++ b/components/atoms/Input/Input.masks.jsx
@@ -114,6 +114,17 @@ export const numberMask = {
   regex: /[0-9]+/,
 };
 
+/** @constant {object} - A percentage mask that does not allow decimals */
+export const percentageWithoutDecimalMask = {
+  mask: createNumberMask({
+    prefix: '',
+    allowDecimal: false,
+    integerLimit: 3,
+    includeThousandsSeparator: false,
+  }),
+  regex: /[0-9]+/,
+};
+
 /** @constant {object} - A percentage mask that allows decimals */
 export const percentageWithDecimalMask = {
   mask: createNumberMask({
@@ -144,7 +155,7 @@ export const percentageWithDecimalMaskAllowNegative = {
 export const smallPercentageWithDecimalMask = {
   mask: createNumberMask({
     prefix: '',
-    allowDecimal: true,
+    allowDecimal: false,
     includeThousandsSeparator: false,
     decimalLimit: 3,
     integerLimit: 2,
@@ -186,6 +197,7 @@ export const maskEnum = {
   CurrencyDecimal: {mask: currencyDecimalMask},
   CurrencyAllowNegative: {mask: currencyMaskAllowNegative},
   Number: {mask: numberMask},
+  percentageWithoutDecimal: {mask: percentageWithoutDecimalMask},
   PercentageWithDecimal: {mask: percentageWithDecimalMask},
   PercentageWithDecimalAllowNegative: {
     mask: percentageWithDecimalMaskAllowNegative,
@@ -196,6 +208,7 @@ export const maskEnum = {
 /** @constant {Array} - Masks that should have '%' appended to it */
 export const percentageMasks = [
   'SmallPercentageWithDecimal',
+  'percentageWithoutDecimal',
   'PercentageWithDecimal',
   'PercentageWithDecimalAllowNegative',
 ];

--- a/components/atoms/Input/Input.masks.jsx
+++ b/components/atoms/Input/Input.masks.jsx
@@ -117,7 +117,7 @@ export const numberMask = {
 /** @constant {regex[]} The mask for a zip code */
 export const percentageWithoutDecimalMask = {
   mask: [/[1-9]/, /\d/, /\d/],
-  regex: /^[0-9]*$/,
+  regex: /[0-9]+/,
 };
 
 /** @constant {object} - A percentage mask that allows decimals */

--- a/components/atoms/Input/Input.masks.jsx
+++ b/components/atoms/Input/Input.masks.jsx
@@ -114,15 +114,10 @@ export const numberMask = {
   regex: /[0-9]+/,
 };
 
-/** @constant {object} - A percentage mask that does not allow decimals */
+/** @constant {regex[]} The mask for a zip code */
 export const percentageWithoutDecimalMask = {
-  mask: createNumberMask({
-    prefix: '',
-    allowDecimal: false,
-    integerLimit: 3,
-    includeThousandsSeparator: false,
-  }),
-  regex: /[0-9]+/,
+  mask: [/[1-9]/, /\d/, /\d/],
+  regex: /^[0-9]*$/,
 };
 
 /** @constant {object} - A percentage mask that allows decimals */
@@ -155,7 +150,7 @@ export const percentageWithDecimalMaskAllowNegative = {
 export const smallPercentageWithDecimalMask = {
   mask: createNumberMask({
     prefix: '',
-    allowDecimal: false,
+    allowDecimal: true,
     includeThousandsSeparator: false,
     decimalLimit: 3,
     integerLimit: 2,

--- a/components/atoms/Input/Input.masks.jsx
+++ b/components/atoms/Input/Input.masks.jsx
@@ -192,7 +192,7 @@ export const maskEnum = {
   CurrencyDecimal: {mask: currencyDecimalMask},
   CurrencyAllowNegative: {mask: currencyMaskAllowNegative},
   Number: {mask: numberMask},
-  percentageWithoutDecimal: {mask: percentageWithoutDecimalMask},
+  PercentageWithoutDecimal: {mask: percentageWithoutDecimalMask},
   PercentageWithDecimal: {mask: percentageWithDecimalMask},
   PercentageWithDecimalAllowNegative: {
     mask: percentageWithDecimalMaskAllowNegative,

--- a/components/atoms/Input/Input.masks.jsx
+++ b/components/atoms/Input/Input.masks.jsx
@@ -203,7 +203,7 @@ export const maskEnum = {
 /** @constant {Array} - Masks that should have '%' appended to it */
 export const percentageMasks = [
   'SmallPercentageWithDecimal',
-  'percentageWithoutDecimal',
+  'PercentageWithoutDecimal',
   'PercentageWithDecimal',
   'PercentageWithDecimalAllowNegative',
 ];

--- a/components/atoms/Input/Input.masks.jsx
+++ b/components/atoms/Input/Input.masks.jsx
@@ -114,7 +114,7 @@ export const numberMask = {
   regex: /[0-9]+/,
 };
 
-/** @constant {regex[]} The mask for a zip code */
+/** @constant {regex[]} A percentage mask that does not allow decimals */
 export const percentageWithoutDecimalMask = {
   mask: [/[1-9]/, /\d/, /\d/],
   regex: /[0-9]+/,

--- a/components/atoms/Input/Input.story.jsx
+++ b/components/atoms/Input/Input.story.jsx
@@ -43,6 +43,7 @@ export const inputMask = (defaultMask) =>
       'CurrencyAllowNegative',
       'Number',
       'PercentageWithDecimal',
+      'percentageWithoutDecimal',
       'SmallPercentageWithDecimal',
       'PercentageWithDecimalAllowNegative',
     ],

--- a/components/atoms/Input/Input.story.jsx
+++ b/components/atoms/Input/Input.story.jsx
@@ -43,7 +43,7 @@ export const inputMask = (defaultMask) =>
       'CurrencyAllowNegative',
       'Number',
       'PercentageWithDecimal',
-      'percentageWithoutDecimal',
+      'PercentageWithoutDecimal',
       'SmallPercentageWithDecimal',
       'PercentageWithDecimalAllowNegative',
     ],

--- a/components/organisms-simple/QuestionCard/QuestionCard.story.jsx
+++ b/components/organisms-simple/QuestionCard/QuestionCard.story.jsx
@@ -155,7 +155,7 @@ stories.add('active with simple form', () => (
       ]}
       value="montezuma"
       disabled
-      description="The acount to transfer the money to."
+      description="The account to transfer the money to."
       label="To"
     />
 


### PR DESCRIPTION
### Description
> Please provide a brief description of your changes below.

This adds a new mask that limits input to 3 integers without decimals

### Testing Instructions
> What should be done in order to test this pull request, or re-create its effects.

Make sure mask is appropriately disallowing non-numerical or decimal characters.

### Screenshots
> If this pull request includes a visual change please attach any applicable screenshots.

N/A

