### PR TITLE
Extract an IconProps type

### DIFF
--- a/components/atoms/icons/AddIcon/AddIcon.tsx
+++ b/components/atoms/icons/AddIcon/AddIcon.tsx
@@ -1,19 +1,10 @@
 /** @module AddIcon */
 import React, {FC, memo} from 'react';
+import {IconProps} from '../icons';
 
-type AddIconProps = {
+type AddIconProps = IconProps & {
   /** Title for the svg. */
   title?: string;
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the AddIcon component.*/

--- a/components/atoms/icons/AdminIcon/AdminIcon.tsx
+++ b/components/atoms/icons/AdminIcon/AdminIcon.tsx
@@ -1,27 +1,9 @@
 /** @module AdminIcon */
 import React, {FC, memo} from 'react';
-
-type AdminIconProps = {
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the AdminIcon component.*/
-const AdminIcon: FC<AdminIconProps> = ({
-  width,
-  height,
-  fill,
-  className,
-  style,
-}) => (
+const AdminIcon: FC<IconProps> = ({width, height, fill, className, style}) => (
   <svg
     className={className}
     xmlns="http://www.w3.org/2000/svg"

--- a/components/atoms/icons/ArrowEllipsisIcon/ArrowEllipsisIcon.tsx
+++ b/components/atoms/icons/ArrowEllipsisIcon/ArrowEllipsisIcon.tsx
@@ -1,21 +1,9 @@
 /** @module ArrowEllipsisIcon */
 import React, {FC, memo} from 'react';
-
-type ArrowEllipsisIconProps = {
-  /** The width of the arrow with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the arrow with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the arrow. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the ArrowEllipsisIcon component.*/
-const ArrowEllipsisIcon: FC<ArrowEllipsisIconProps> = ({
+const ArrowEllipsisIcon: FC<IconProps> = ({
   width,
   height,
   fill,

--- a/components/atoms/icons/ArrowIcon/ArrowIcon.tsx
+++ b/components/atoms/icons/ArrowIcon/ArrowIcon.tsx
@@ -1,20 +1,11 @@
 /** @module ArrowIcon */
 import classNames from 'classnames';
 import React, {FC, memo} from 'react';
+import {IconProps} from '../icons';
 
-type ArrowIconProps = {
-  /** The width of the arrow with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the arrow with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the arrow. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
+type ArrowIconProps = IconProps & {
   /** Changes the direction of the arrow. */
   direction?: 'up' | 'right' | 'down' | 'left';
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the ArrowIcon component.*/

--- a/components/atoms/icons/ArrowLineIcon/ArrowLineIcon.story.jsx
+++ b/components/atoms/icons/ArrowLineIcon/ArrowLineIcon.story.jsx
@@ -15,7 +15,6 @@ stories.addParameters({
 const defaultProps = () => ({
   fill: text('fill', '#000'),
   height: text('height', '44.5rem'),
-  width: text('width', '1.3rem'),
   direction: select('direction', ['down', 'up', 'right', 'left'], 'down'),
 });
 

--- a/components/atoms/icons/ArrowLineIcon/ArrowLineIcon.tsx
+++ b/components/atoms/icons/ArrowLineIcon/ArrowLineIcon.tsx
@@ -1,19 +1,12 @@
 /** @module ArrowLineIcon */
 import classNames from 'classnames';
 import React, {FC, memo} from 'react';
+import {IconProps} from '../icons';
 import './ArrowLineIcon.scss';
 
-type ArrowLineIconProps = {
-  /** The height of the arrow with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the arrow. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
+type ArrowLineIconProps = Omit<IconProps, 'width'> & {
   /** Changes the direction of the arrow. */
   direction?: 'up' | 'right' | 'down' | 'left';
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the ArrowLineIcon component.*/

--- a/components/atoms/icons/CaretIcon/CaretIcon.tsx
+++ b/components/atoms/icons/CaretIcon/CaretIcon.tsx
@@ -2,22 +2,13 @@
 import classNames from 'classnames';
 import React, {FC, memo} from 'react';
 import {colors} from '~constants/js/colors';
+import {IconProps} from '../icons';
 
-type CaretIconProps = {
-  /** The width of the arrow with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the arrow with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the arrow. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
+type CaretIconProps = IconProps & {
   /** The stroke size of the icon which adjusts the thickness. */
   stroke?: string;
   /** Changes the direction of the arrow. */
   direction?: 'up' | 'right' | 'down' | 'left';
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the CaretIcon component.*/

--- a/components/atoms/icons/CheckIcon/CheckIcon.tsx
+++ b/components/atoms/icons/CheckIcon/CheckIcon.tsx
@@ -1,17 +1,8 @@
 /** @module CheckIcon */
 import React, {FC, memo} from 'react';
+import {IconProps} from '../icons';
 
-type CheckIconProps = {
-  /** The width of the arrow with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the arrow with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the arrow. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
+type CheckIconProps = IconProps & {
   /** Determines if the checkbox should have a background or not. */
   removeBackground?: boolean;
 };

--- a/components/atoms/icons/ClearIcon/ClearIcon.tsx
+++ b/components/atoms/icons/ClearIcon/ClearIcon.tsx
@@ -1,27 +1,9 @@
 /** @module ClearIcon */
 import React, {FC, memo} from 'react';
-
-type ClearIconProps = {
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the ClearIcon component.*/
-const ClearIcon: FC<ClearIconProps> = ({
-  width,
-  height,
-  fill,
-  className,
-  style,
-}) => (
+const ClearIcon: FC<IconProps> = ({width, height, fill, className, style}) => (
   <svg
     className={className}
     xmlns="http://www.w3.org/2000/svg"

--- a/components/atoms/icons/CloseIcon/CloseIcon.tsx
+++ b/components/atoms/icons/CloseIcon/CloseIcon.tsx
@@ -1,27 +1,9 @@
 /** @module CloseIcon */
 import React, {FC, memo} from 'react';
-
-type CloseIconProps = {
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the CloseIcon component.*/
-const CloseIcon: FC<CloseIconProps> = ({
-  width,
-  height,
-  fill,
-  className,
-  style,
-}) => (
+const CloseIcon: FC<IconProps> = ({width, height, fill, className, style}) => (
   <svg
     className={className}
     xmlns="http://www.w3.org/2000/svg"

--- a/components/atoms/icons/DiceIcon/DiceIcon.tsx
+++ b/components/atoms/icons/DiceIcon/DiceIcon.tsx
@@ -1,27 +1,9 @@
 /** @module DiceIcon */
 import React, {FC, memo} from 'react';
-
-type DiceIconProps = {
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the DiceIcon component.*/
-const DiceIcon: FC<DiceIconProps> = ({
-  width,
-  height,
-  fill,
-  className,
-  style,
-}) => {
+const DiceIcon: FC<IconProps> = ({width, height, fill, className, style}) => {
   return (
     <svg
       className={className}

--- a/components/atoms/icons/ErrorFlagIcon/ErrorFlagIcon.tsx
+++ b/components/atoms/icons/ErrorFlagIcon/ErrorFlagIcon.tsx
@@ -1,21 +1,9 @@
 /** @module ErrorFlagIcon */
 import React, {FC, memo} from 'react';
-
-type ErrorFlagIconProps = {
-  /** The width of the arrow with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the arrow with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the arrow. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the ErrorFlagIcon component.*/
-const ErrorFlagIcon: FC<ErrorFlagIconProps> = ({
+const ErrorFlagIcon: FC<IconProps> = ({
   width,
   height,
   fill,

--- a/components/atoms/icons/ExpandyCircleIcon/ExpandyCircleIcon.tsx
+++ b/components/atoms/icons/ExpandyCircleIcon/ExpandyCircleIcon.tsx
@@ -1,20 +1,11 @@
 /** @module ExpandyCircleIcon */
 import classNames from 'classnames';
 import React, {FC, memo} from 'react';
+import {IconProps} from '../icons';
 
-type ExpandyCircleIconProps = {
-  /** The width of the arrow with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the arrow with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the arrow. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
+type ExpandyCircleIconProps = IconProps & {
   /** Changes the direction of the arrow. */
   direction?: 'up' | 'right' | 'down' | 'left';
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the ExpandyCircleIcon component. */

--- a/components/atoms/icons/FacebookIcon/FacebookIcon.tsx
+++ b/components/atoms/icons/FacebookIcon/FacebookIcon.tsx
@@ -1,21 +1,9 @@
 /** @module FacebookIcon */
 import React, {FC, memo} from 'react';
-
-type FacebookIconProps = {
-  /** The width of the with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the FacebookIcon component.*/
-const FacebookIcon: FC<FacebookIconProps> = ({
+const FacebookIcon: FC<IconProps> = ({
   width,
   height,
   fill,

--- a/components/atoms/icons/HamburgerIcon/HamburgerIcon.tsx
+++ b/components/atoms/icons/HamburgerIcon/HamburgerIcon.tsx
@@ -1,21 +1,9 @@
 /** @module HamburgerIcon */
 import React, {FC, memo} from 'react';
-
-type HamburgerIconProps = {
-  /** The width of the with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the hamburger with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the hamburger. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the HamburgerIcon component.*/
-const HamburgerIcon: FC<HamburgerIconProps> = ({
+const HamburgerIcon: FC<IconProps> = ({
   width,
   height,
   fill,

--- a/components/atoms/icons/HouseIcon/HouseIcon.tsx
+++ b/components/atoms/icons/HouseIcon/HouseIcon.tsx
@@ -1,14 +1,11 @@
 /** @module HouseIcon */
 import classNames from 'classnames';
 import React, {FC, Fragment} from 'react';
-import {colors} from '~constants/js/colors';
 import detectBrowser from '~components/utilities/DetectBrowser/DetectBrowser';
+import {colors} from '~constants/js/colors';
+import {IconProps} from '../icons';
 
-type HouseIconProps = {
-  /** The width of the arrow with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the arrow with unit sizing (px, rem, etc). */
-  height?: string;
+type HouseIconProps = Omit<IconProps, 'fill'> & {
   /** Animations are disabled for ie users as they don't work. */
   isIE: boolean;
   /** Unique identifier for the house component block. */
@@ -17,10 +14,6 @@ type HouseIconProps = {
   houses: number;
   /** How many of the houses should be highlight. */
   highlight?: number;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the HouseIcon component.*/

--- a/components/atoms/icons/InfoIcon/InfoIcon.tsx
+++ b/components/atoms/icons/InfoIcon/InfoIcon.tsx
@@ -1,20 +1,13 @@
 /** @module InfoIcon */
 import React, {FC, memo} from 'react';
 import {colors} from '~constants/js/colors';
+import {IconProps} from '../icons';
 
-type InfoIconProps = {
-  /** The width of the infoIcon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the InfoIcon with unit sizing (px, rem, etc). */
-  height?: string;
+type InfoIconProps = Omit<IconProps, 'fill'> & {
   /** The color of the background. */
   circleFill?: string;
   /** The color of the "i" inside the circle. */
   iconFill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the InfoIcon component.*/

--- a/components/atoms/icons/LinkedInIcon/LinkedInIcon.tsx
+++ b/components/atoms/icons/LinkedInIcon/LinkedInIcon.tsx
@@ -1,19 +1,10 @@
 /** @module LinkedInIcon */
 import React, {FC, memo} from 'react';
+import {IconProps} from '../icons';
 
-type LinkedInIconProps = {
-  /** The width of the with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
+type LinkedInIconProps = IconProps & {
   /** Boolean to toggle the full icon vs the logo (defaults to false) */
   isFull?: boolean;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the LinkedInIcon component.*/

--- a/components/atoms/icons/LockCircleIcon/LockCircleIcon.tsx
+++ b/components/atoms/icons/LockCircleIcon/LockCircleIcon.tsx
@@ -1,18 +1,9 @@
 /** @module LockCircleIcon */
 import React, {FC} from 'react';
 import {colors} from '../../../../constants/js/colors';
+import {IconProps} from '../icons';
 
-type LockCircleIconProps = {
-  /* Additional class names to apply to the container. */
-  className?: string;
-  /** Additional style properties to apply to the container. */
-  style?: React.CSSProperties;
-  /** The width of the with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
+type LockCircleIconProps = IconProps & {
   /** The color of the circle that surrounds the icon. */
   outerFill?: string;
   /** The aria label for the lock icon. */

--- a/components/atoms/icons/PrinterCircleIcon/PrinterCircleIcon.tsx
+++ b/components/atoms/icons/PrinterCircleIcon/PrinterCircleIcon.tsx
@@ -1,21 +1,9 @@
 /** @module PrinterCircleIcon */
 import React, {FC, memo} from 'react';
-
-type PrinterCircleIconProps = {
-  /** The width of the with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the PrinterCircleIcon component.*/
-const PrinterCircleIcon: FC<PrinterCircleIconProps> = ({
+const PrinterCircleIcon: FC<IconProps> = ({
   width,
   height,
   fill,

--- a/components/atoms/icons/PrinterIcon/PrinterIcon.tsx
+++ b/components/atoms/icons/PrinterIcon/PrinterIcon.tsx
@@ -1,21 +1,9 @@
 /** @module PrinterIcon */
 import React, {FC, memo} from 'react';
-
-type PrinterIconProps = {
-  /** The width of the with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the PrinterIcon component.*/
-const PrinterIcon: FC<PrinterIconProps> = ({
+const PrinterIcon: FC<IconProps> = ({
   width,
   height,
   fill,

--- a/components/atoms/icons/SaveIcon/SaveIcon.tsx
+++ b/components/atoms/icons/SaveIcon/SaveIcon.tsx
@@ -1,19 +1,10 @@
 /** @module SaveIcon */
 import React, {FC, memo} from 'react';
+import {IconProps} from '../icons';
 
-type SaveIconProps = {
+type SaveIconProps = IconProps & {
   /** Title for the svg. */
   title?: string;
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the SaveIcon component.*/

--- a/components/atoms/icons/StarCircleIcon/StarCircleIcon.tsx
+++ b/components/atoms/icons/StarCircleIcon/StarCircleIcon.tsx
@@ -1,20 +1,11 @@
 /** @module StarCircleIcon */
 import React, {FC, memo} from 'react';
 import {colors} from '~constants/js/colors';
+import {IconProps} from '../icons';
 
-type StarCircleIconProps = {
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
+type StarCircleIconProps = IconProps & {
   /** The outer color of the icon. */
   outerFill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the StarCircleIcon component.*/

--- a/components/atoms/icons/StarIcon/StarIcon.tsx
+++ b/components/atoms/icons/StarIcon/StarIcon.tsx
@@ -1,27 +1,9 @@
 /** @module StarIcon */
 import React, {FC, memo} from 'react';
-
-type StarIconProps = {
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the StarIcon component.*/
-const StarIcon: FC<StarIconProps> = ({
-  width,
-  height,
-  fill,
-  className,
-  style,
-}) => (
+const StarIcon: FC<IconProps> = ({width, height, fill, className, style}) => (
   <svg
     className={className}
     xmlns="http://www.w3.org/2000/svg"

--- a/components/atoms/icons/ThumbsDownIcon/ThumbsDownIcon.tsx
+++ b/components/atoms/icons/ThumbsDownIcon/ThumbsDownIcon.tsx
@@ -1,21 +1,9 @@
 /** @module ThumbsDownIcon */
 import React, {FC, memo} from 'react';
-
-type ThumbsDownIconProps = {
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the ThumbsDownIcon component.*/
-const ThumbsDownIcon: FC<ThumbsDownIconProps> = ({
+const ThumbsDownIcon: FC<IconProps> = ({
   width,
   height,
   fill,

--- a/components/atoms/icons/ThumbsUpIcon/ThumbsUpIcon.tsx
+++ b/components/atoms/icons/ThumbsUpIcon/ThumbsUpIcon.tsx
@@ -1,21 +1,9 @@
 /** @module ThumbsUpIcon */
 import React, {FC, memo} from 'react';
-
-type ThumbsUpIconProps = {
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the ThumbsUpIcon component.*/
-const ThumbsUpIcon: FC<ThumbsUpIconProps> = ({
+const ThumbsUpIcon: FC<IconProps> = ({
   width,
   height,
   fill,

--- a/components/atoms/icons/TradeIcon/TradeIcon.tsx
+++ b/components/atoms/icons/TradeIcon/TradeIcon.tsx
@@ -1,19 +1,10 @@
 /** @module TradeIcon */
 import React, {FC, memo} from 'react';
+import {IconProps} from '../icons';
 
-type TradeIconProps = {
+type TradeIconProps = IconProps & {
   /** Title for the svg. */
   title?: string;
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
 };
 
 /** Displays the TradeIcon component.*/

--- a/components/atoms/icons/TrashIcon/TrashIcon.tsx
+++ b/components/atoms/icons/TrashIcon/TrashIcon.tsx
@@ -1,27 +1,9 @@
 /** @module TrashIcon */
 import React, {FC, memo} from 'react';
-
-type TrashIconProps = {
-  /** The width of the icon with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the TrashIcon component.*/
-const TrashIcon: FC<TrashIconProps> = ({
-  width,
-  height,
-  fill,
-  className,
-  style,
-}) => (
+const TrashIcon: FC<IconProps> = ({width, height, fill, className, style}) => (
   <svg
     className={className}
     xmlns="http://www.w3.org/2000/svg"

--- a/components/atoms/icons/TwitterIcon/TwitterIcon.tsx
+++ b/components/atoms/icons/TwitterIcon/TwitterIcon.tsx
@@ -1,21 +1,9 @@
 /** @module TwitterIcon */
 import React, {FC, memo} from 'react';
-
-type TwitterIconProps = {
-  /** The width of the with unit sizing (px, rem, etc). */
-  width?: string;
-  /** The height of the icon with unit sizing (px, rem, etc). */
-  height?: string;
-  /** The color of the icon. */
-  fill?: string;
-  /** Additional class names to apply to the container. */
-  className?: string;
-  /** Additional inline styles to apply to the container. */
-  style?: React.CSSProperties;
-};
+import {IconProps} from '../icons';
 
 /** Displays the TwitterIcon component.*/
-const TwitterIcon: FC<TwitterIconProps> = ({
+const TwitterIcon: FC<IconProps> = ({
   width,
   height,
   fill,

--- a/components/atoms/icons/icons.d.ts
+++ b/components/atoms/icons/icons.d.ts
@@ -1,0 +1,12 @@
+export type IconProps = {
+  /** Additional class names to apply to the container. */
+  className?: string;
+  /** Additional inline styles to apply to the container. */
+  style?: React.CSSProperties;
+  /** The color of the icon. */
+  fill?: string;
+  /** The height of the icon with unit sizing (px, rem, etc). */
+  height?: string;
+  /** The width of the icon with unit sizing (px, rem, etc). */
+  width?: string;
+};


### PR DESCRIPTION
### Description
A lot of the icon components shared a collection of types. I extracted those shared types into a single type that the components could share. 

### Comments
`ArrowLineIcon`, `HouseIcon`, and `InfoIcon` buck the trend of conformity so I `Omit` a prop from those. I'm wondering if people have opinions about this. 

At first, I started thinking that the `IconProps` that I'd pulled out weren't universal _enough_ to warrant getting extracted. Upon further reflection, it feels like calling out the strangeness of the previously mentioned icon components by tying them to the shared `IconProps` type makes their novelty more obvious. 
