### PR TITLE
Fix McGonagall active card

### DIFF
--- a/components/templates/McGonagall/McGonagall.tsx
+++ b/components/templates/McGonagall/McGonagall.tsx
@@ -242,7 +242,7 @@ class McGonagall<TContext = DefaultContext> extends Component<
   get activeCard(): string {
     const queryStringCard = queryString.parse(this.props.location.search).step;
 
-    if (typeof queryStringCard !== 'string') {
+    if (Array.isArray(queryStringCard)) {
       throw new Error('multiple card values found in query string');
     }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@unitedincome/components",
   "description": "Component library for all United Income applications.",
   "author": "United Income <engineering@unitedincome.com>",
-  "version": "2.0.37",
+  "version": "2.0.38",
   "main": "dist/index.js",
   "types": "dist/components/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
### Description
There is a point when a flow initially loads where there is no `step` query param. This modified check in `activeCard` prevents the component from throwing during that time.
